### PR TITLE
Add a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Godot-specific ignores
+.import/
+build/
+
+# Mono-specific ignores
+.mono/
+data_*/


### PR DESCRIPTION
Ignores the .import folder which Godot uses for imported resources and should not be committed.