### PR TITLE
Add a default scene for running tests in batches

### DIFF
--- a/BatchTester/BatchTester.gd
+++ b/BatchTester/BatchTester.gd
@@ -1,0 +1,185 @@
+extends Control
+
+var scene_count
+var scenes = []
+var dirs = []
+var roots = {}
+var current_dir
+var current
+var results = {}
+var fps_samples = []
+
+onready var start_button : Button = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/StartButton"
+onready var test_option_button : OptionButton = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/TestOptionButton"
+onready var stop_button : Button = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/StopButton"
+onready var viewport : Viewport = $"MarginContainer/VBoxContainer2/MarginContainer/ViewportContainer/Viewport"
+onready var next_button : Button = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/NextButton"
+onready var current_test_label : Label = $"MarginContainer/VBoxContainer2/VBoxContainer/CurrentTestLabel"
+onready var result_tree : Tree = $"MarginContainer/VBoxContainer2/MarginContainer/ResultTree"
+onready var time_spin_box : SpinBox = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer2/TimeSpinBox"
+onready var next_test_timer : Timer = $NextTestTimer
+onready var run_all_button : Button = $"MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/RunAllButton"
+onready var test_progress_bar : ProgressBar = $"MarginContainer/VBoxContainer2/VBoxContainer/Progress/TestProgressBar"
+onready var progress : Control = $"MarginContainer/VBoxContainer2/VBoxContainer/Progress"
+onready var get_fps_timer : Timer = $GetFPSTimer
+
+func _ready() -> void:
+	set_process(false)
+	result_tree.set_column_titles_visible(true)
+	result_tree.set_column_title(0, "Test")
+	result_tree.set_column_title(1, "FPS")
+	result_tree.create_item()
+
+
+func _process(_delta : float) -> void:
+	test_progress_bar.max_value = (scene_count - 1) * time_spin_box.value + next_test_timer.wait_time
+	test_progress_bar.value = (scene_count - scenes.size() - 1) * time_spin_box.value + next_test_timer.wait_time - next_test_timer.time_left
+
+
+func start_tests(test_dir):
+	scenes.clear()
+	results[test_dir] = []
+	var dir = Directory.new()
+	var test_folder = "res://".plus_file(test_dir)
+	current_dir = test_dir
+	dir.open(test_folder)
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	while file_name != "":
+		var file = test_folder.plus_file(file_name)
+		if ResourceLoader.exists(file, "PackedScene"):
+			scenes.append(load(file).instance())
+		file_name = dir.get_next()
+	scene_count = scenes.size()
+	stop_button.show()
+	next_button.show()
+	progress.show()
+	current_test_label.show()
+	result_tree.hide()
+	start_next_test()
+	set_process(true)
+
+
+func start_next_test():
+	if current:
+		var test_name = current.filename.get_basename().get_file()
+		if not fps_samples.empty():
+			var sum_fps = 0
+			for fps in fps_samples:
+				sum_fps += fps
+			results[current_dir].append({
+				name = test_name,
+				time = sum_fps / fps_samples.size(),
+			})
+		viewport.remove_child(current)
+	if scenes.empty():
+		finish_testing()
+		return
+	current = scenes.pop_front()
+	current_test_label.text = "Currently testing %s" % current.filename.get_basename().get_file()
+	viewport.add_child(current)
+	fps_samples.clear()
+	next_button.disabled = scenes.empty()
+	next_test_timer.start(time_spin_box.value)
+	yield(get_tree().create_timer(1.0), "timeout")
+	get_fps_timer.start()
+
+
+class ResultSorter:
+	static func sort_by_time_ascending(a, b):
+		return a.time < b.time
+
+
+func finish_testing():
+	if not current:
+		return
+	stop_button.hide()
+	next_button.hide()
+	progress.hide()
+	current_test_label.hide()
+	next_test_timer.stop()
+	get_fps_timer.stop()
+	if current.get_parent():
+		viewport.remove_child(current)
+	current.queue_free()
+	set_process(false)
+	current = null
+	scenes.clear()
+	results[current_dir].sort_custom(ResultSorter.new(), "sort_by_time_ascending")
+	var root : TreeItem = roots.get(current_dir)
+	if not root:
+		root = result_tree.create_item(result_tree.get_root())
+		root.set_text(0, current_dir)
+		roots[current_dir] = root
+	var child = root.get_children()
+	while child != null:
+		root.remove_child(child)
+		child = child.get_next()
+	for test in results[current_dir]:
+		var item = result_tree.create_item(root)
+		item.set_text(0, test.name)
+		item.set_text(1, str(test.time))
+		if test == results[current_dir].back():
+			item.set_custom_color(0, Color.lightgreen)
+			item.set_custom_color(1, Color.lightgreen)
+	result_tree.show()
+	next_dir()
+
+
+func next_dir():
+	if dirs.empty():
+		return
+	start_tests(dirs.pop_front())
+
+
+func _on_StartButton_pressed() -> void:
+	if current:
+		finish_testing()
+	start_tests(test_option_button.text)
+
+
+func _on_StopButton_pressed() -> void:
+	dirs.clear()
+	viewport.remove_child(current)
+	finish_testing()
+
+
+func _on_NextButton_pressed() -> void:
+	start_next_test()
+
+
+func _on_NextTestTimer_timeout() -> void:
+	start_next_test()
+
+
+func _on_RunAllButton_pressed() -> void:
+	finish_testing()
+	dirs.clear()
+	for item_num in test_option_button.get_item_count():
+		dirs.append(test_option_button.get_item_text(item_num))
+	next_dir()
+
+
+func _on_CopyResultsButton_pressed() -> void:
+	var markdown = "# Results\n"
+	for dir in results:
+		markdown += "\n## %s\n\n| Test | FPS |\n| --- | --- |\n" % dir
+		for test in results[dir]:
+			var elements = [test.name, test.time]
+			if test == results[dir].back():
+				for element_num in elements.size():
+					elements[element_num] = "**%s**" % elements[element_num]
+			markdown += "| %s | %s |\n" % elements
+	OS.clipboard = markdown
+
+
+func _on_GetFPSTimer_timeout() -> void:
+	fps_samples.append(Engine.get_frames_per_second())
+
+
+func _on_CopyCSVButton_pressed() -> void:
+	var csv = "Test Name,FPS,Test Suite\n"
+	for dir in results:
+		for test in results[dir]:
+			csv += "%s,%s,%s\n" % [test.name, test.time, dir]
+	OS.clipboard = csv

--- a/BatchTester/BatchTester.tscn
+++ b/BatchTester/BatchTester.tscn
@@ -1,0 +1,215 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://BatchTester/BatchTester.gd" type="Script" id=1]
+
+[node name="BatchTester" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_right = 20
+custom_constants/margin_top = 20
+custom_constants/margin_left = 20
+custom_constants/margin_bottom = 20
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="MarginContainer"]
+margin_left = 20.0
+margin_top = 20.0
+margin_right = 1004.0
+margin_bottom = 580.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer2"]
+margin_right = 984.0
+margin_bottom = 66.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer2/VBoxContainer"]
+margin_right = 984.0
+margin_bottom = 20.0
+alignment = 1
+
+[node name="TestOptionButton" type="OptionButton" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer"]
+margin_left = 355.0
+margin_right = 485.0
+margin_bottom = 20.0
+rect_min_size = Vector2( 130, 0 )
+text = "DistanceChecks"
+clip_text = true
+items = [ "DistanceChecks", null, false, 0, null, "LineOfSightChecks", null, false, 1, null, "Pathfinding", null, false, 2, null, "Movement", null, false, 3, null, "VisionCone", null, false, 4, null, "ShootingBullets", null, false, 5, null, "AlphaScissorVsComplexGeometry", null, false, 6, null, "ArmIK", null, false, 7, null ]
+selected = 0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StartButton" type="Button" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer"]
+margin_left = 489.0
+margin_right = 568.0
+margin_bottom = 20.0
+text = "Start Tests"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StopButton" type="Button" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer"]
+visible = false
+margin_left = 523.0
+margin_right = 601.0
+margin_bottom = 20.0
+text = "Stop Tests"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="NextButton" type="Button" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer"]
+visible = false
+margin_left = 564.0
+margin_right = 637.0
+margin_bottom = 20.0
+text = "Next Test"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="RunAllButton" type="Button" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer"]
+margin_left = 572.0
+margin_right = 629.0
+margin_bottom = 20.0
+text = "Run All"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer2/VBoxContainer"]
+margin_top = 24.0
+margin_right = 984.0
+margin_bottom = 48.0
+alignment = 1
+
+[node name="TimeLabel" type="Label" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer2"]
+margin_left = 397.0
+margin_top = 5.0
+margin_right = 508.0
+margin_bottom = 19.0
+text = "Seconds per test:"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="TimeSpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer2"]
+margin_left = 512.0
+margin_right = 586.0
+margin_bottom = 24.0
+min_value = 2.0
+max_value = 5.0
+step = 0.5
+value = 2.0
+allow_greater = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Progress" type="Control" parent="MarginContainer/VBoxContainer2/VBoxContainer"]
+visible = false
+margin_top = 52.0
+margin_right = 984.0
+margin_bottom = 72.0
+rect_min_size = Vector2( 0, 20 )
+
+[node name="TestProgressBar" type="ProgressBar" parent="MarginContainer/VBoxContainer2/VBoxContainer/Progress"]
+anchor_left = 0.2
+anchor_right = 0.8
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CurrentTestLabel" type="Label" parent="MarginContainer/VBoxContainer2/VBoxContainer"]
+margin_top = 52.0
+margin_right = 984.0
+margin_bottom = 66.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.52
+text = "Current Test:"
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer2"]
+margin_top = 70.0
+margin_right = 984.0
+margin_bottom = 560.0
+size_flags_vertical = 3
+
+[node name="ViewportContainer" type="ViewportContainer" parent="MarginContainer/VBoxContainer2/MarginContainer"]
+margin_right = 984.0
+margin_bottom = 490.0
+stretch = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="MarginContainer/VBoxContainer2/MarginContainer/ViewportContainer"]
+size = Vector2( 984, 490 )
+handle_input_locally = false
+render_target_update_mode = 3
+
+[node name="ResultTree" type="Tree" parent="MarginContainer/VBoxContainer2/MarginContainer"]
+margin_right = 984.0
+margin_bottom = 490.0
+columns = 2
+hide_root = true
+
+[node name="CopyResultsButton" type="Button" parent="MarginContainer/VBoxContainer2/MarginContainer/ResultTree"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -292.255
+margin_top = -33.4166
+margin_right = -136.255
+margin_bottom = -13.4166
+text = "Copy Result Markdown"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CopyCSVButton" type="Button" parent="MarginContainer/VBoxContainer2/MarginContainer/ResultTree"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -128.265
+margin_top = -33.4166
+margin_right = -14.2649
+margin_bottom = -13.4166
+text = "Copy Result CSV"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="NextTestTimer" type="Timer" parent="."]
+
+[node name="GetFPSTimer" type="Timer" parent="."]
+wait_time = 0.2
+
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/StartButton" to="." method="_on_StartButton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/StopButton" to="." method="_on_StopButton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/NextButton" to="." method="_on_NextButton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/VBoxContainer/HBoxContainer/RunAllButton" to="." method="_on_RunAllButton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/MarginContainer/ResultTree/CopyResultsButton" to="." method="_on_CopyResultsButton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer2/MarginContainer/ResultTree/CopyCSVButton" to="." method="_on_CopyCSVButton_pressed"]
+[connection signal="timeout" from="NextTestTimer" to="." method="_on_NextTestTimer_timeout"]
+[connection signal="timeout" from="GetFPSTimer" to="." method="_on_GetFPSTimer_timeout"]

--- a/ShootingBullets/ShootBulletsBasic.tscn
+++ b/ShootingBullets/ShootBulletsBasic.tscn
@@ -3,31 +3,31 @@
 [ext_resource path="res://ShootingBullets/assets/BulletInstancer.gd" type="Script" id=1]
 [ext_resource path="res://FPSDisplay.tscn" type="PackedScene" id=2]
 
-[sub_resource type="CubeMesh" id=3]
+[sub_resource type="CubeMesh" id=1]
 size = Vector3( 16, 5, 2 )
 
-[sub_resource type="SpatialMaterial" id=4]
+[sub_resource type="SpatialMaterial" id=2]
 albedo_color = Color( 0, 0.227451, 1, 1 )
 
-[sub_resource type="BoxShape" id=5]
+[sub_resource type="BoxShape" id=3]
 extents = Vector3( 8, 2.5, 1 )
 
-[sub_resource type="CubeMesh" id=1]
+[sub_resource type="CubeMesh" id=4]
 
-[sub_resource type="SpatialMaterial" id=2]
+[sub_resource type="SpatialMaterial" id=5]
 albedo_color = Color( 1, 0, 0, 1 )
 
 [node name="ShootBulletsBasic" type="Spatial"]
 
 [node name="Wall" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -60 )
-mesh = SubResource( 3 )
-material/0 = SubResource( 4 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )
 
 [node name="StaticBody" type="StaticBody" parent="Wall"]
 
 [node name="CollisionShape" type="CollisionShape" parent="Wall/StaticBody"]
-shape = SubResource( 5 )
+shape = SubResource( 3 )
 
 [node name="Camera2" type="Camera" parent="Wall"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0.501556, 35.4148, 15.9698 )
@@ -38,13 +38,13 @@ script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="BulletInstancer3"]
 transform = Transform( 0.3, 0, 0, 0, 0.3, 0, 0, 0, 0.57, 0, 0, 0 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="BulletInstancer3"]
 transform = Transform( 0.3, 0, 0, 0, -1.31134e-08, 0.57, 0, -0.3, -2.49155e-08, 0, -0.0892401, 0.280691 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="BulletInstancer4" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3 )
@@ -52,13 +52,13 @@ script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="BulletInstancer4"]
 transform = Transform( 0.3, 0, 0, 0, 0.3, 0, 0, 0, 0.57, 0, 0, 0 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="BulletInstancer4"]
 transform = Transform( 0.3, 0, 0, 0, -1.31134e-08, 0.57, 0, -0.3, -2.49155e-08, 0, -0.0892401, 0.280691 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="BulletInstancer5" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 0, 3 )
@@ -66,13 +66,13 @@ script = ExtResource( 1 )
 
 [node name="MeshInstance" type="MeshInstance" parent="BulletInstancer5"]
 transform = Transform( 0.3, 0, 0, 0, 0.3, 0, 0, 0, 0.57, 0, 0, 0 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="BulletInstancer5"]
 transform = Transform( 0.3, 0, 0, 0, -1.31134e-08, 0.57, 0, -0.3, -2.49155e-08, 0, -0.0892401, 0.280691 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+mesh = SubResource( 4 )
+material/0 = SubResource( 5 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 0.707107, -0.17414, 0.685328, 0, 0.969201, 0.246272, -0.707107, -0.17414, 0.685328, 11, 3, 4 )

--- a/ShootingBullets/assets/BulletInstancer.gd
+++ b/ShootingBullets/assets/BulletInstancer.gd
@@ -17,4 +17,4 @@ func fire():
 	var bullet_inst = bullet_obj.instance()
 	bullet_inst.global_transform = global_transform
 	bullet_inst.connect("hit_something", bullet_inst, "queue_free")
-	get_tree().get_root().add_child(bullet_inst)
+	get_parent().add_child(bullet_inst)

--- a/ShootingBullets/assets/BulletPoolSpawner.gd
+++ b/ShootingBullets/assets/BulletPoolSpawner.gd
@@ -17,5 +17,5 @@ func _process(delta):
 func fire():
 	var bullet_inst = bullet_pool.get_bullet()
 	bullet_inst.global_transform = global_transform
-	get_tree().get_root().add_child(bullet_inst)
+	get_parent().add_child(bullet_inst)
 	bullet_inst.init()

--- a/ShootingBullets/assets/HitEffectSpawner.gd
+++ b/ShootingBullets/assets/HitEffectSpawner.gd
@@ -15,7 +15,7 @@ func spawn_hit_effect(pos: Vector3, normal: Vector3):
 	else:
 		hit_effect_inst = hit_effect_pool.get_hit_effect()
 	hit_effect_inst.global_transform = get_transform_from_hit_data(pos, normal)
-	get_tree().get_root().add_child(hit_effect_inst)
+	get_parent().get_parent().add_child(hit_effect_inst)
 	hit_effect_inst.init()
 
 func get_transform_from_hit_data(pos: Vector3, dir: Vector3):

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,7 @@ _global_script_class_icons={
 [application]
 
 config/name="PerformanceTests"
+run/main_scene="res://BatchTester/BatchTester.tscn"
 config/icon="res://icon.png"
 
 [display]


### PR DESCRIPTION
This adds a central hub where the user can run tests and evaluate the results. It allows running all test scenes from a directory, skipping and stopping running tests, setting the time each test will run and testing all folders back to back. A progress bar shows how long the tests will take.

When a test ran the configured amount of time, the average FPS value is stored in the results, which are displayed in a table with the items sorted by performance. When running a test multiple times, the previous results of that test are overridden.

The results can be copied as csv or as markdown, which looks like this:

<details>

# Results
	
## DistanceChecks

| Test | FPS |
| --- | --- |
| DistCheckQuery | 144 |
| DistCheckHashTable | 145 |
| DistCheckAreaProcess | 146 |
| DistCheckAreaDetectAreaProcess | 204 |
| DistCheckBasic | 246 |
| DistCheckAreaProcess | 264 |
| DistCheckBasic | 272 |
| DistCheckAreaSignals | 293 |
| DistCheckHashTable | 342 |
| DistCheckAreaDetectAreaProcess | 351 |
| DistCheckAreaSignals | 367 |
| **DistCheckQuery** | **435** |

## LineOfSightChecks

| Test | FPS |
| --- | --- |
| RaycastLoSAlternate | 145 |
| RaycastLoS | 503 |
| RaycastLoS | 540 |
| **RaycastLoSAlternate** | **541** |

## Pathfinding

| Test | FPS |
| --- | --- |
| QueuedPathfinding | 145 |
| BasicPathfinding | 145 |
| SepThreadQueuedPathfinding | 145 |
| BasicPathfinding | 540 |
| SepThreadQueuedPathfinding | 573 |
| **QueuedPathfinding** | **588** |

## Movement

| Test | FPS |
| --- | --- |
| MoveAndCollide | 144 |
| MoveAndSlide | 145 |
| MoveAndSlideWithSnap | 145 |
| MoveAndSlideWithSnap | 313 |
| MoveAndCollide | 360 |
| **MoveAndSlide** | **361** |

## VisionCone

| Test | FPS |
| --- | --- |
| VisionConeAngleCalc | 145 |
| VisionConeDotProdNoSqrt | 145 |
| VisionConeDotProd | 145 |
| VisionConeDotProdNoSqrt | 157 |
| VisionConeAngleCalc | 159 |
| **VisionConeDotProd** | **159** |

## ShootingBullets

| Test | FPS |
| --- | --- |
| ShootBulletsBasic | 145 |
| ShootBulletsPooling | 145 |
| ShootBulletsBasic | 500 |
| **ShootBulletsPooling** | **502** |

## AlphaScissorVsComplexGeometry

| Test | FPS |
| --- | --- |
| ComplexGeoTwoMats | 42 |
| ComplexGeo | 42 |
| BothGeoAndAlpha | 64 |
| AlphaScissor | 102 |
| AlphaScissor | 145 |
| ComplexGeoTwoMats | 145 |
| BothGeoAndAlpha | 145 |
| **ComplexGeo** | **145** |

## ArmIK

| Test | FPS |
| --- | --- |
| ArmIKBasic | 145 |
| ArmIKQueue | 145 |
| ArmIKBasic | 453 |
| **ArmIKQueue** | **491** |
</details>

**When running a test:**

![image](https://user-images.githubusercontent.com/28286961/122675075-26db9d00-d1d8-11eb-9aff-3c8efce438a7.png)

**When the test finishes:**

![image](https://user-images.githubusercontent.com/28286961/122675056-13c8cd00-d1d8-11eb-8101-9943159336ee.png)
